### PR TITLE
[SVG] [Fix] Bypass `<foreignObject>` checking

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const {
  * @param {string} parent
  * @returns {boolean}
  */
-function isValidHTMLNesting(parent, child) {
+function isValidHTMLNesting(parent, child) { 
 	// if we know the list of children that are the only valid children for the given parent
 	if (parent in onlyValidChildren) {
 		return onlyValidChildren[parent].has(child);
@@ -36,6 +36,12 @@ function isValidHTMLNesting(parent, child) {
 		// if so, return false
 		if (knownInvalidParents[child].has(parent)) return false;
 	}
+
+    // SVG foreign objects, child could be literally anythng
+    if(parent === "foreignObject")
+    {
+        return true;
+    }
 
 	// SVG tags should only contain SVG tags or anchor tag
 	if (svgTags.has(parent) && child !== 'a' && !svgTags.has(child)) {

--- a/tests/validation.test.js
+++ b/tests/validation.test.js
@@ -127,3 +127,11 @@ test('headings', () => {
 	// valid
 	expect(isValidHTMLNesting('h1', 'div')).toBe(true);
 });
+
+test('foreignObject', () => {
+    expect(isValidHTMLNesting('foreignObject', 'div')).toBe(true);
+    expect(isValidHTMLNesting('foreignObject', 'a')).toBe(true);
+    expect(isValidHTMLNesting('foreignObject', 'textarea')).toBe(true);
+    expect(isValidHTMLNesting('foreignObject', 'xxx')).toBe(true);
+    expect(isValidHTMLNesting('foreignObject', '😉')).toBe(true);
+});


### PR DESCRIPTION
There is a problem with `<foreignObject>` tag. It is as special tag which could be used to embedd HTML markup into svg, or some other "foreign ns xml's".

And as you check it yourself it doesn't work. We encounter this issue while trying to make some html inside svg markup using solid-js. The fun part it has been woking (fot 2 month or so), but after some update in dependencies it got broken.

I not sure if there is any better way then just bypass checks for foreignObject tag, but most likely it will work fine.