### PR TITLE
Allow div as parent of dt, dd

### DIFF
--- a/src/mapping.js
+++ b/src/mapping.js
@@ -53,8 +53,8 @@ const onlyValidParents = {
 	thead: new Set(['table']),
 	tr: new Set(['tbody', 'thead', 'tfoot']),
 	// data list
-	dd: new Set(['dl']),
-	dt: new Set(['dl']),
+	dd: new Set(['dl', 'div']),
+	dt: new Set(['dl', 'div']),
 	// other
 	figcaption: new Set(['figure']),
 	// li: new Set(["ul", "ol"]),

--- a/tests/validation.test.js
+++ b/tests/validation.test.js
@@ -150,4 +150,17 @@ describe('SVG', () => {
 		expect(isValidHTMLNesting('g', 'textarea')).toBe(true);
 		expect(isValidHTMLNesting('g', 'g')).toBe(true);
 	});
+
+	test('dl', () => {
+		// valid
+		expect(isValidHTMLNesting('dl', 'dt')).toBe(true);
+		expect(isValidHTMLNesting('dl', 'dd')).toBe(true);
+		expect(isValidHTMLNesting('dl', 'div')).toBe(true);
+		expect(isValidHTMLNesting('div', 'dt')).toBe(true);
+		expect(isValidHTMLNesting('div', 'dd')).toBe(true);
+
+		// invalid
+		expect(isValidHTMLNesting('span', 'dt')).toBe(false);
+		expect(isValidHTMLNesting('span', 'dd')).toBe(false);
+	});
 });


### PR DESCRIPTION
Fixes #5.

This does not appear to mess with browser parsing and is in the spec https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element.