### PR TITLE
more customizable select support

### DIFF
--- a/src/mapping.js
+++ b/src/mapping.js
@@ -18,7 +18,7 @@ const onlyValidChildren = {
 		'template',
 	]),
 	optgroup: new Set(['option']),
-	select: new Set(['optgroup', 'option', 'hr', 'button']),
+	select: new Set(['optgroup', 'option', 'hr', 'button', 'div']),
 	math: new Set(['mrow']),
 	script: new Set(),
 	// table
@@ -30,7 +30,7 @@ const onlyValidChildren = {
 	tfoot: new Set(['tr']),
 	// these elements can not have any children elements
 	iframe: emptySet,
-	option: emptySet,
+	option: new Set(['abbr', 'b', 'bdi', 'bdo', 'br', 'canvas', 'cite', 'code', 'data', 'del', 'dfn', 'div', 'em', 'i', 'img', 'ins', 'kbd', 'link', 'mark', 'meter', 'noscript', 'output', 'picture', 'progress', 'q', 'ruby', 's', 'samp', 'script', 'small', 'span', 'strong', 'sub', 'sup', 'template', 'time', 'u', 'var', 'wbr']),
 	textarea: emptySet,
 	style: emptySet,
 	title: emptySet,

--- a/tests/validation.test.js
+++ b/tests/validation.test.js
@@ -24,6 +24,7 @@ test('select', () => {
 	expect(isValidHTMLNesting('select', 'optgroup')).toBe(true);
 	expect(isValidHTMLNesting('select', 'hr')).toBe(true);
 	expect(isValidHTMLNesting('select', 'button')).toBe(true);
+	expect(isValidHTMLNesting('select', 'div')).toBe(true);
 });
 
 test('p', () => {


### PR DESCRIPTION
It is really hard to find some official HTML specs on this, so I did some more testing / trail & error to figure out what exactly those 

> other markup structures like images, other non-interactive text-level semantic elements, and more.

for a [customizable select option element](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Content_categories#phrasing_content) are.

Turns out, latest Firefox 140.0b8 does not even support their own MDN example of customizable select LOL 🤪
Only `<hr/>` as child works, all other "valid" elements are converted to just plain text content.

The new `options Set` is tested in Chromium / Google Chrome 137.0.7151.68 to work and not have errors for

<details>
<summary>

`Non-phrasing content used within an <option> element`

</summary>

> `The <option> element allows only non-interactive phrasing content, text, and <div> elements as its children. The semantics of non-phrasing content elements do not make sense as children of an <option>, and such semantics will largely be ignored by assistive technology since they are inappropriate in this context. Consider removing or changing such elements to one of the allowed phrasing content elements.`

</details>

Anyways I propose to merge, as browser support will hopefully follow soon